### PR TITLE
Hotfix: fix agentes pending payment status

### DIFF
--- a/src/app/main/pages/agentes/AgentesApp.js
+++ b/src/app/main/pages/agentes/AgentesApp.js
@@ -38,6 +38,7 @@ import JwtService from "src/app/auth/services/jwtService";
 import { isAdminUser } from "src/app/auth/utils/accessUtils";
 import { BankInfo, getUserCpf, PersonalInfo } from "../profile/formCards/formCards";
 import {
+  buildMonthlyPaymentRowKey,
   getAgentesDashboard,
 } from "./services/agentesService";
 import {
@@ -262,6 +263,10 @@ function StatusBadge({ status }) {
 
 function getPermissionarioStatus(statusRemessa, paymentStatus) {
   if (statusRemessa === null || statusRemessa === undefined || statusRemessa === "") {
+    if (paymentStatus === "Pendência de Pagamento") {
+      return paymentStatus;
+    }
+
     return "A pagar";
   }
 
@@ -281,8 +286,12 @@ function getPermissionarioStatus(statusRemessa, paymentStatus) {
   }
 }
 
-function getPermissionarioBadgeColor(statusRemessa) {
+function getPermissionarioBadgeColor(statusRemessa, paymentStatus) {
   if (statusRemessa === null || statusRemessa === undefined || statusRemessa === "") {
+    if (paymentStatus === "Pendência de Pagamento") {
+      return "error";
+    }
+
     return "op";
   }
 
@@ -341,7 +350,7 @@ function ValidPhotosStatusBadge({ status, paymentStatus }) {
   return (
     <Badge
       className="whitespace-nowrap"
-      color={getPermissionarioBadgeColor(status)}
+      color={getPermissionarioBadgeColor(status, paymentStatus)}
       badgeContent={getPermissionarioStatus(status, paymentStatus)}
       sx={statusBadgeSx}
     />
@@ -642,12 +651,12 @@ const DashboardDrilldownCard = memo(function DashboardDrilldownCard({
       </TableRow>
     ));
   } else if (monthlyPayments?.length) {
-    monthlyPaymentsRows = monthlyPayments.map((payment) => {
+    monthlyPaymentsRows = monthlyPayments.map((payment, index) => {
       const isSelected = selectedPaymentDate === payment.paymentDate;
 
       return (
         <TableRow
-          key={payment.paymentDate}
+          key={buildMonthlyPaymentRowKey(payment, index)}
           hover
           selected={isSelected}
         // onClick={() => handleSelectMonthlyPayment(payment.paymentDate)}

--- a/src/app/main/pages/agentes/services/agentesService.js
+++ b/src/app/main/pages/agentes/services/agentesService.js
@@ -1,4 +1,4 @@
-import { api } from "app/configs/api/api";
+import { api } from "../../../../configs/api/api";
 import JwtService from "../../../../auth/services/jwtService";
 import jwtServiceConfig from "../../../../auth/services/jwtService/jwtServiceConfig";
 
@@ -41,14 +41,26 @@ function normalizeIdsArray(ids) {
     .filter((item) => Number.isFinite(item) && item > 0);
 }
 
-function getPaymentStatus(statusRemessa, descricaoStatusRemessa) {
-  if (Number(statusRemessa) === 4) {
-    return "Pendente";
-  }
+function hasRemittanceStatus(statusRemessa) {
+  return (
+    statusRemessa !== null &&
+    statusRemessa !== undefined &&
+    statusRemessa !== ""
+  );
+}
 
+export function getPaymentStatus(statusRemessa, descricaoStatusRemessa) {
   const normalizedDescription = String(descricaoStatusRemessa || "")
     .trim()
     .toLowerCase();
+
+  if (normalizedDescription.includes("naoefet")) {
+    return "Rejeitado";
+  }
+
+  if (Number(statusRemessa) === 4) {
+    return "Pendente";
+  }
 
   if (normalizedDescription.includes("efet")) {
     return "Pago";
@@ -62,11 +74,26 @@ function getPaymentStatus(statusRemessa, descricaoStatusRemessa) {
     return "Pago";
   }
 
-  if (Number(statusRemessa) === 31) {
+  if (Number(statusRemessa) === 1) {
     return "Aguardando Pagamento";
   }
 
+  if (!hasRemittanceStatus(statusRemessa) && !normalizedDescription) {
+    return "A pagar";
+  }
+
   return "Rejeitado";
+}
+
+function shouldMarkPaymentAsPendingWithoutStatus(payment) {
+  const hasPositiveValue = normalizeNumber(payment?.totalPaymentValue) > 0;
+  const hasMissingStatus = !hasRemittanceStatus(payment?.statusRemessa);
+  const hasMissingReason =
+    payment?.motivoStatusRemessa == null &&
+    payment?.descricaoMotivoStatusRemessa == null &&
+    !String(payment?.pendingReason || "").trim();
+
+  return hasPositiveValue && hasMissingStatus && hasMissingReason;
 }
 
 function markPreviousAttemptsAsPending(monthlyPayments) {
@@ -88,10 +115,7 @@ function markPreviousAttemptsAsPending(monthlyPayments) {
       (laterPayment) => {
         const laterPaymentAttemptDate =
           laterPayment.dataTentativaPagamento || laterPayment.paymentDate;
-        const hasStatus =
-          laterPayment.statusRemessa !== null &&
-          laterPayment.statusRemessa !== undefined &&
-          laterPayment.statusRemessa !== "";
+        const hasStatus = hasRemittanceStatus(laterPayment.statusRemessa);
 
         return (
           paymentAttemptDate &&
@@ -102,6 +126,13 @@ function markPreviousAttemptsAsPending(monthlyPayments) {
     );
     const isLatestPendingAttempt =
       paymentAttemptDate === latestPaymentAttemptDate;
+
+    if (shouldMarkPaymentAsPendingWithoutStatus(payment)) {
+      return {
+        ...payment,
+        paymentStatus: "Pendência de Pagamento",
+      };
+    }
 
     if (
       Number(payment.statusRemessa) !== 4 ||
@@ -117,7 +148,26 @@ function markPreviousAttemptsAsPending(monthlyPayments) {
   });
 }
 
-function buildMonthlyPaymentRows(monthlyResponse) {
+export function buildMonthlyPaymentRowKey(payment, index) {
+  const groupedIds = normalizeCommaIds(payment?.ordemPagamentoAgrupadoIds);
+
+  if (groupedIds) {
+    return groupedIds;
+  }
+
+  return [
+    toDateOnly(payment?.paymentDate),
+    toDateOnly(payment?.dataTentativaPagamento),
+    toDateOnly(payment?.dataEfetivaPagamento),
+    normalizeNumber(payment?.totalPaymentValue).toFixed(2),
+    String(payment?.statusRemessa ?? "null"),
+    String(payment?.motivoStatusRemessa ?? "null"),
+    String(payment?.descricaoMotivoStatusRemessa ?? "null"),
+    index,
+  ].join(":");
+}
+
+export function buildMonthlyPaymentRows(monthlyResponse) {
   const monthlyOrders = Array.isArray(monthlyResponse?.ordens)
     ? monthlyResponse.ordens
     : [];

--- a/src/app/main/pages/agentes/services/agentesService.test.js
+++ b/src/app/main/pages/agentes/services/agentesService.test.js
@@ -1,0 +1,98 @@
+jest.mock("../../../../configs/api/api", () => ({
+  api: {
+    request: jest.fn(),
+  },
+}));
+
+jest.mock("../../../../auth/services/jwtService", () => ({
+  __esModule: true,
+  default: {
+    isAuthTokenValid: jest.fn(),
+  },
+}));
+
+jest.mock("../../../../auth/services/jwtService/jwtServiceConfig", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import {
+  buildMonthlyPaymentRowKey,
+  buildMonthlyPaymentRows,
+  getPaymentStatus,
+} from "./agentesService";
+
+describe("agentesService payment normalization", () => {
+  it("keeps rows without a remittance attempt as A pagar", () => {
+    const monthlyRows = buildMonthlyPaymentRows({
+      ordens: [
+        {
+          data: "2026-08-28T00:00:00.000Z",
+          valorTotal: 0,
+          statusRemessa: null,
+          descricaoStatusRemessa: null,
+          dataTentativaPagamento: "2026-08-28T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(monthlyRows).toHaveLength(1);
+    expect(monthlyRows[0].statusRemessa).toBeNull();
+    expect(monthlyRows[0].paymentStatus).toBe("A pagar");
+  });
+
+  it("marks rows with value and no remittance status as Pendência de Pagamento", () => {
+    const monthlyRows = buildMonthlyPaymentRows({
+      ordens: [
+        {
+          data: "2026-08-28T00:00:00.000Z",
+          valorTotal: 142.35,
+          statusRemessa: null,
+          descricaoStatusRemessa: null,
+          motivoStatusRemessa: null,
+          descricaoMotivoStatusRemessa: null,
+          dataTentativaPagamento: "2026-08-28T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(monthlyRows).toHaveLength(1);
+    expect(monthlyRows[0].statusRemessa).toBeNull();
+    expect(monthlyRows[0].paymentStatus).toBe("Pendência de Pagamento");
+  });
+
+  it("treats NaoEfetivado as Rejeitado instead of Pago", () => {
+    expect(getPaymentStatus(4, "NaoEfetivado")).toBe("Rejeitado");
+  });
+
+  it("builds distinct row keys for same-date monthly rows", () => {
+    const monthlyRows = buildMonthlyPaymentRows({
+      ordens: [
+        {
+          ordemGuardadorId: 1,
+          nomeGuardador: "TELMA CLOTILDE",
+          ordemPagamentoAgrupadoIds: "491928",
+          data: "2026-08-25T00:00:00.000Z",
+          valorTotal: 1.4,
+          statusRemessa: 4,
+          descricaoStatusRemessa: "NaoEfetivado",
+          dataTentativaPagamento: "2026-08-25T00:00:00.000Z",
+        },
+        {
+          ordemGuardadorId: 2,
+          nomeGuardador: "ANTERO GOMES COELHO NETO",
+          ordemPagamentoAgrupadoIds: null,
+          data: "2026-08-25T00:00:00.000Z",
+          valorTotal: 0,
+          statusRemessa: null,
+          descricaoStatusRemessa: null,
+          dataTentativaPagamento: "2026-08-25T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(buildMonthlyPaymentRowKey(monthlyRows[0], 0)).not.toBe(
+      buildMonthlyPaymentRowKey(monthlyRows[1], 1)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- show `Pendência de Pagamento` for monthly rows with payment value but no valid remittance status or reason
- preserve the existing error color for that pending-payment badge in the agentes screen
- add regression coverage for pending-payment, `NaoEfetivado`, and duplicate monthly row keys

## Testing
- npm test -- --runInBand --watch=false src/app/main/pages/agentes/services/agentesService.test.js